### PR TITLE
Reverting syntax highligher background colour

### DIFF
--- a/assets/scss/_syntax-highlighting.scss
+++ b/assets/scss/_syntax-highlighting.scss
@@ -7,7 +7,7 @@
   color: #ffffff;
 
   .highlighter-rouge &, &, .hll, pre, code {
-    background-color: lighten($light-gray-color, 15%) !important;
+    background-color: #2b2b2b !important;
   }
 
   table td {


### PR DESCRIPTION
During merge conflict resolution in #6 , CSS has been erroneously modified. Reverting changes to ensure code blocks text is readable.